### PR TITLE
Making httpMethod upper cased

### DIFF
--- a/Sources/VoiNetwork/APIRequest.swift
+++ b/Sources/VoiNetwork/APIRequest.swift
@@ -58,7 +58,7 @@ public extension APIRequest {
         guard let url = urlComponents.url else { return nil }
         
         var request = URLRequest(url: url)
-        request.httpMethod = method.rawValue.capitalized
+        request.httpMethod = method.rawValue.uppercased()
         request.cachePolicy = cachingPolicy
         requestHeaders?.forEach { (key: String, value: String) in
             request.addValue(value, forHTTPHeaderField: key)

--- a/Tests/VoiNetworkTests/APIRequestTests.swift
+++ b/Tests/VoiNetworkTests/APIRequestTests.swift
@@ -10,11 +10,12 @@ import XCTest
 import VoiNetwork
 
 class APIRequestTests: XCTestCase {
-
+    
     func testUrlRequestQueryItems_withPath_withoutQueryParameters() {
         let mockRequest = MockRequest.requestPathWithoutQueryparameters
         let urlRequest = mockRequest.urlRequest
         let urlComponents = URLComponents.init(url: urlRequest!.url!, resolvingAgainstBaseURL: true)
+        XCTAssertEqual(urlRequest?.httpMethod, "GET")
         XCTAssertNil(urlComponents?.queryItems)
     }
     
@@ -22,6 +23,7 @@ class APIRequestTests: XCTestCase {
         let mockRequest = MockRequest.requestPathWithQueryparameters
         let urlRequest = mockRequest.urlRequest
         let urlComponents = URLComponents.init(url: urlRequest!.url!, resolvingAgainstBaseURL: true)
+        XCTAssertEqual(urlRequest?.httpMethod, "POST")
         XCTAssertNotNil(urlComponents?.queryItems)
         XCTAssertEqual(urlComponents!.queryItems!.count, 2)
     }
@@ -30,8 +32,15 @@ class APIRequestTests: XCTestCase {
         let mockRequest = MockRequest.requestPathWithoutQueryparametersButHasPropertyQueryParameters
         let urlRequest = mockRequest.urlRequest
         let urlComponents = URLComponents.init(url: urlRequest!.url!, resolvingAgainstBaseURL: true)
+        XCTAssertEqual(urlRequest?.httpMethod, "PUT")
         XCTAssertNotNil(urlComponents?.queryItems)
         XCTAssertEqual(urlComponents!.queryItems!.count, 3)
+    }
+    
+    func testRequestUsingPATCH_isCapitalised() {
+        let mockRequest = MockRequest.requestUsingPATCH
+        let urlRequest = mockRequest.urlRequest
+        XCTAssertEqual(urlRequest?.httpMethod, "PATCH")
     }
 }
 
@@ -39,11 +48,12 @@ enum MockRequest: APIRequest {
     case requestPathWithQueryparameters
     case requestPathWithoutQueryparameters
     case requestPathWithoutQueryparametersButHasPropertyQueryParameters
+    case requestUsingPATCH
     
     var baseURLPath: String {
         switch self {
         case .requestPathWithoutQueryparameters, .requestPathWithoutQueryparametersButHasPropertyQueryParameters: return "https://example.com"
-        case .requestPathWithQueryparameters: return ""
+        case .requestPathWithQueryparameters, .requestUsingPATCH: return ""
         }
     }
     
@@ -51,20 +61,22 @@ enum MockRequest: APIRequest {
         switch self {
         case .requestPathWithoutQueryparameters: return "/path"
         case .requestPathWithQueryparameters, .requestPathWithoutQueryparametersButHasPropertyQueryParameters: return urlWithQueryparameters
+        case .requestUsingPATCH: return ""
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .requestPathWithoutQueryparameters: return .put
-        case .requestPathWithQueryparameters: return .put
+        case .requestPathWithoutQueryparameters: return .get
+        case .requestPathWithQueryparameters: return .post
         case .requestPathWithoutQueryparametersButHasPropertyQueryParameters: return .put
+        case .requestUsingPATCH: return .patch
         }
     }
     
     var queryParameters: [String: String]? {
         switch self {
-        case .requestPathWithoutQueryparameters, .requestPathWithQueryparameters: return nil
+        case .requestPathWithoutQueryparameters, .requestPathWithQueryparameters, .requestUsingPATCH: return nil
         case .requestPathWithoutQueryparametersButHasPropertyQueryParameters: return ["key": "value"]
         }
     }


### PR DESCRIPTION
When using Patch as http method, the request stays capitalised, and it won't get approved by backend

https://voidev.atlassian.net/browse/IP-150