### PR TITLE
Add FailableDecodable to VoiNetwork

### DIFF
--- a/Sources/VoiNetwork/APIRequest.swift
+++ b/Sources/VoiNetwork/APIRequest.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Voi Technology. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 public enum HTTPMethod: String {
     case get

--- a/Sources/VoiNetwork/FailableDecodable.swift
+++ b/Sources/VoiNetwork/FailableDecodable.swift
@@ -1,0 +1,20 @@
+//
+//  FailableDecodable.swift
+//  voi-app
+//
+//  Created by Mayur Deshmukh on 2020-02-20.
+//  Copyright © 2020 Voi Technology. All rights reserved.
+//
+
+import Foundation
+
+/// `FailableDecodable` helps us not fail when we have an array of Decodable elements. When we try to decode a JSON data containing one or more corrupt JSON objects in an array, we do not want to fail the entire main decodable. Hence we should use this helper class wherever we have arrays in Decodables, and filter out the failed objects using `compactMap()`
+struct FailableDecodable<Base: Decodable>: Decodable {
+
+    let base: Base?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.base = try? container.decode(Base.self)
+    }
+}

--- a/Tests/VoiNetworkTests/FailableDecodableTests.swift
+++ b/Tests/VoiNetworkTests/FailableDecodableTests.swift
@@ -1,0 +1,98 @@
+//
+//  FailableDecodableTests.swift
+//  VoiNetworkTests
+//
+//  Created by Mayur Deshmukh on 2020-10-14.
+//
+
+import XCTest
+@testable import VoiNetwork
+
+final class ApiTestService {}
+
+extension ApiTestService {
+    struct TestEndpoint {
+        struct ResponseBody: Decodable {
+            private let data: [FailableDecodable<TestItem>]
+            
+            var validData: [TestItem] {
+                return data.compactMap { $0.base }
+            }
+            
+            struct TestItem: Decodable {
+                let id: String
+                let name: String
+                let discount: Double?
+                private let tags: [FailableDecodable<String>]?
+                
+                var validTags: [String]? {
+                    return tags?.compactMap { $0.base }
+                }
+            }
+        }
+    }
+}
+
+let testStrJson = """
+{
+  "data": [
+    {
+      "id": "a8f50a28-0e61-11eb-adc1-0242ac120002",
+      "name": "Valid Item with discount",
+      "discount": 0.15,
+      "tags": [
+        "Valid",
+        "Discount",
+        "Valid tags"
+      ]
+    },
+    {
+      "id": "a8f50a28-0e61-11eb-adc1-0242ac120003",
+      "name": "Valid Item without discount",
+      "tags": [
+        "Valid",
+        "Some invalid tags",
+        99,
+        true
+      ]
+    },
+    {
+      "id": "a8f50a28-0e61-11eb-adc1-0242ac120007",
+      "name": "Valid Item without discount",
+      "tags": [
+        99,
+        true
+      ]
+    },
+    {
+      "id": "a8f50a28-0e61-11eb-adc1-0242ac120004",
+      "name": "Valid Item without discount"
+    },
+    {
+      "ide": "a8f50a28-0e61-11eb-adc1-0242ac120005",
+      "name": "Invalid Item with discount",
+      "discount": 0.25
+    },
+    {
+      "name": "Invalid Item without discount"
+    }
+  ]
+}
+"""
+
+let testData = testStrJson.data(using: .utf8)!
+
+class FailableDecodableTests: XCTestCase {
+
+    func testDecodingEntitiesContainingFailableDecodables() throws {
+        //If decoding fails, the test function will throw and test will fail.
+        let responseBody: ApiTestService.TestEndpoint.ResponseBody = try JSONDecoder().decode(ApiTestService.TestEndpoint.ResponseBody.self, from: testData)
+        
+        XCTAssertEqual(responseBody.validData.count, 4) // 4 valid `TestItems` are received
+        XCTAssertEqual(responseBody.validData[0].validTags!.count, 3) // First test item contains all 3 valid tags
+        XCTAssertEqual(responseBody.validData[1].validTags!.count, 2) // Second test item contains 2 valid tags, the 2 invalid tags are filtered
+        XCTAssertEqual(responseBody.validData[2].validTags!.count, 0) // Third test item contains 0 valid tags, the 2 invalid tags are filtered
+        XCTAssertNil(responseBody.validData[3].validTags) // Fourth test item has Optional<Nil> valid tags
+    }
+
+}


### PR DESCRIPTION
This PR adds the `FailableDecodable` to VoiNetwork as it has a role to play in network layer for parsing Response entities which might have Array of Codables that have a chance of one failing all. We can thus also share this with every project that uses VoiNetwork.