### PR TITLE
Added custom parsing strategy

### DIFF
--- a/Sources/VoiNetwork/APIParser.swift
+++ b/Sources/VoiNetwork/APIParser.swift
@@ -1,0 +1,101 @@
+//
+//  APIParser.swift
+//  
+//
+//  Created by Dmytro Benedyk on 09.11.2020.
+//
+
+import Foundation
+
+public protocol APIParser {
+    associatedtype Response: Decodable
+    associatedtype CustomError: Decodable & Error
+    
+    func parseData(_ result: Data?, jsonDecoder: JSONDecoder) -> Result<Decodable?, Error>
+    
+    var isSuccess: Bool { get }
+}
+
+public class AnyParser {
+    private let parseDataBlock: (Data?, JSONDecoder) -> Result<Decodable?, Error>
+    private let successBlock: () -> Bool
+    private var parser: Any
+    
+    public init<T: APIParser>(parser: T) {
+        self.parser = parser
+        self.parseDataBlock = { (data, decoder) in
+            return parser.parseData(data, jsonDecoder: decoder)
+        }
+        self.successBlock = {
+            return parser.isSuccess
+        }
+    }
+}
+
+extension AnyParser: APIParser {
+    public typealias Response = AnyResponse
+    public typealias CustomError = AnyError
+    
+    public func parseData(_ result: Data?, jsonDecoder: JSONDecoder = JSONDecoder()) -> Result<Decodable?, Error> {
+        return self.parseDataBlock(result, jsonDecoder)
+    }
+    
+    public var isSuccess: Bool {
+        get {
+            return self.successBlock()
+        }
+    }
+    
+}
+
+public final class AnyResponse: Decodable {
+    public init(from decoder: Decoder) throws {
+        fatalError()
+    }
+}
+
+public final class AnyError: Decodable, Error {
+    public init(from decoder: Decoder) throws {
+        fatalError()
+    }
+}
+
+public extension APIParser {
+    var isSuccess: Bool {
+        get {
+            return true
+        }
+    }
+    
+    func parseData(_ result: Data?, jsonDecoder: JSONDecoder = JSONDecoder()) -> Result<Decodable?, Error> {
+        
+        func tryParse<T: Decodable>(_ data: Data, jsonDecoder: JSONDecoder = JSONDecoder()) throws -> T {
+            if T.self is String.Type, let parsed = String(data: data, encoding: .utf8) as? T {
+                return parsed
+            }
+            return try jsonDecoder.decode(T.self, from: data)
+        }
+        
+        do {
+            if isSuccess {
+                if let data = result {
+                    let parsed: Response = try tryParse(data, jsonDecoder: jsonDecoder)
+                    return .success(parsed)
+                } else {
+                    return .success(nil)
+                }
+            } else {
+                if let data = result {
+                    let parsed: CustomError = try tryParse(data, jsonDecoder: jsonDecoder)
+                    return .failure(parsed)
+                } else {
+                    return .failure(APIServiceError.couldNotParseToSpecifiedModel)
+                }
+            }
+        }
+        catch( _ ) {
+            return .failure(APIServiceError.couldNotParseToSpecifiedModel)
+        }
+    }
+    
+}

--- a/Sources/VoiNetwork/APIRequest.swift
+++ b/Sources/VoiNetwork/APIRequest.swift
@@ -24,6 +24,7 @@ public enum HTTPBody {
 }
 
 public protocol APIRequest {
+    
     // Required
     var baseURLPath: String { get }
     var path: String { get }
@@ -34,7 +35,7 @@ public protocol APIRequest {
     var body: HTTPBody? { get }
     var requestHeaders: [String: String]? { get }
     var cachingPolicy: URLRequest.CachePolicy { get }
-    
+    var parsersMap: [HTTPStatusCode : AnyParser] { get }
     //Computing URLRequest from above parameters
     var urlRequest: URLRequest? { get }
 }
@@ -42,6 +43,7 @@ public protocol APIRequest {
 public extension APIRequest {
     var requestHeaders: [String: String]? { return nil }
     var queryParameters: [String: String]? { return nil }
+    var parsersMap: [HTTPStatusCode : AnyParser] { return [HTTPStatusCode : AnyParser]() }
     var body: HTTPBody? { return nil }
     var cachingPolicy: URLRequest.CachePolicy { return .reloadIgnoringLocalAndRemoteCacheData }
     

--- a/Tests/VoiNetworkTests/APIExample/APIExampleRequest.swift
+++ b/Tests/VoiNetworkTests/APIExample/APIExampleRequest.swift
@@ -28,6 +28,34 @@ enum APIExampleRequest: APIRequest {
         case .exampleRequestWithDictionaryBody(let dictionary): return .jsonFromDictionary(dictionary: dictionary)
         }
     }
+    
+    var parsersMap: [HTTPStatusCode : AnyParser] {
+        get {
+            return [.ok : AnyParser(parser: APIExampleParser()),
+                    .badRequest: AnyParser(parser: APIExampleErrorParser()),
+                    .noContent: AnyParser(parser: APIExampleErrorParser())]
+        }
+    }
+}
+
+final class APIExampleParser: APIParser {
+    typealias Response = ExampleSuccess
+    typealias CustomError = ExampleError
+    var isSuccess: Bool {
+        get {
+            return true
+        }
+    }
+}
+
+final class APIExampleErrorParser: APIParser {
+    typealias Response = ExampleSuccess
+    typealias CustomError = ExampleError
+    var isSuccess: Bool {
+        get {
+            return false
+        }
+    }
 }
 
 extension APIExampleRequest {

--- a/Tests/VoiNetworkTests/APIExample/APIExampleService.swift
+++ b/Tests/VoiNetworkTests/APIExample/APIExampleService.swift
@@ -20,16 +20,15 @@ struct APIExampleService: APIExampleServiceProtocol {
     
     func requestWithoutErrorHandling(completion: @escaping (Result<ExampleSuccess, Error>) -> Void) {
         let request = APIExampleRequest.exampleRequest
-        performRequest(request) { result in
-            result.parseToType(ExampleSuccess.self, statusCode: .ok, completion: completion)
+        performRequestWithParsing(request) { result in
+            result.convertToType(completion: completion)
         }
     }
     
     func requestWithErrorHandling(completion: @escaping (Result<ExampleSuccess, Error>) -> Void) {
         let request = APIExampleRequest.exampleRequest
-        performRequest(request) { result in
-            result.parseToType(success: (type: ExampleSuccess.self, statusCode: .ok),
-                               error: (type: ExampleError.self, statusCode: .badRequest), completion: completion)
+        performRequestWithParsing(request) { result in
+            result.convertToType(completion: completion)
         }
     }
     

--- a/Tests/VoiNetworkTests/APIExample/APIExampleServiceTests+WithErrorHandling.swift
+++ b/Tests/VoiNetworkTests/APIExample/APIExampleServiceTests+WithErrorHandling.swift
@@ -84,7 +84,7 @@ class APIExampleServiceTests_WithErrorHandling: XCTestCase {
         dispatcher.statusCode = 204
         service.requestWithErrorHandling { result in
             if case .failure(let error) = result, let serviceError = error as? APIServiceError {
-                XCTAssertEqual(serviceError, APIServiceError.statusCodeNotHandled)
+                XCTAssertEqual(serviceError, APIServiceError.couldNotParseToSpecifiedModel)
             } else {
                 XCTFail()
             }

--- a/Tests/VoiNetworkTests/APIExample/APIExampleServiceTests+WithoutErrorHandling.swift
+++ b/Tests/VoiNetworkTests/APIExample/APIExampleServiceTests+WithoutErrorHandling.swift
@@ -54,7 +54,7 @@ class APIExampleServiceTests_WithoutErrorHandling: XCTestCase {
         dispatcher.statusCode = 400
         service.requestWithoutErrorHandling { result in
             if case .failure(let error) = result, let serviceError = error as? APIServiceError {
-                XCTAssertEqual(serviceError, APIServiceError.statusCodeNotHandled)
+                XCTAssertEqual(serviceError, APIServiceError.couldNotParseToSpecifiedModel)
             } else {
                 XCTFail()
             }


### PR DESCRIPTION
I tried to make some sort of Type Eraser that allows us to parse different objects using map settings from request.
1. I don't like to setting abstract classes as typealiases in AnyParser
2. Tried to avoid conversion from Result<Decodable?, Error> to Result<ExactType, Error> but wasn't able to achieve it.
3. Old methods were left for backward compatibility and should be marked as deprecated if we decide to merge this

Tests will be added soon. To see how it works in live please use branch `feature/Network_layer` in the Hunter repository. I changed Profile fetching to use this