### PR TITLE
Parse function variant to prevent code duplication

### DIFF
--- a/Sources/VoiNetwork/APIService.swift
+++ b/Sources/VoiNetwork/APIService.swift
@@ -52,6 +52,20 @@ public extension APIServiceResponse {
         }
         return try jsonDecoder.decode(T.self, from: data)
     }
+
+    func parse<SuccessType: Decodable, ErrorType: Decodable & Error>(success: (type: SuccessType.Type, statusCode: HTTPStatusCode),
+                                       error: (type: ErrorType.Type, statusCode: HTTPStatusCode),
+                                                                     jsonDecoder: JSONDecoder = JSONDecoder()) throws -> SuccessType {
+
+        if statusCode == success.statusCode {
+            return try parse()
+        } else if statusCode == error.statusCode {
+            let error: ErrorType = try parse()
+            throw error
+        } else {
+            throw APIServiceError.statusCodeNotHandled
+        }
+    }
 }
 
 //Mark: Code below is from old API with completion handlers


### PR DESCRIPTION
This PR aims at adding a variant of existing `Parse` function to directly send in Success and Failure type so that we don't need to handle it for each and every API call in Api layer.

Please refer the screenshot attached.

<img width="1679" alt="Screenshot 2024-08-01 at 15 10 32" src="https://github.com/user-attachments/assets/8878983a-b6e1-44f4-8207-436237861e4a">

Also as an example on how to use I have created a pull request here,
https://github.com/voiapp/ios-app/pull/4304